### PR TITLE
refactor(renderer): add `locus` to snippet IR

### DIFF
--- a/lib/rendering/snippet.mli
+++ b/lib/rendering/snippet.mli
@@ -54,6 +54,7 @@ type block =
 (** A source consists of multiple blocks within the same {{!type:Source.t} source}. *)
 and source =
   { source : Source.t (** The source. *)
+  ; locus : Line_index.t * Column_index.t (** The 'locus' position. *)
   ; labels : Label.t list (** The labels within the source. *)
   ; blocks : block list
   (** The list of {!type:block}s. The blocks are non-overlapping and sorted. *)


### PR DESCRIPTION
This PR adds loci to snippets and moves the computation of loci points to `Snippet.of_diagnostic`.

Closes: #6 