### PR TITLE
fix: use `Format.pp_infinity` in `Message.to_string`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ocaml/setup-ocaml@v2
+      - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ocaml-base-compiler.4.14.0
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* fix(core): use `Format.pp_infinity` in `Message.to_string` for OCaml >5.2 ([#40](https://github.com/johnyob/grace/pull/40)
+
 ## 0.2.0 (2024-05-28)
 
 * fix(renderer): remove uncessary underlines when printing a unique 'multi-line `Top` marker' ([#31](https://github.com/johnyob/grace/pull/31))

--- a/lib/core/diagnostic.ml
+++ b/lib/core/diagnostic.ml
@@ -68,7 +68,7 @@ module Message = struct
     let to_string t =
       let buf = Buffer.create 512 in
       let ppf = Format.formatter_of_buffer buf in
-      Format.pp_set_geometry ppf ~max_indent:2 ~margin:Int.max_value;
+      Format.pp_set_geometry ppf ~max_indent:2 ~margin:Format.pp_max_margin;
       t ppf;
       Format.pp_print_flush ppf ();
       Buffer.contents buf

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,4 +3,4 @@
  (public_name grace)
  (libraries core)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_jane ppx_optcomp)))

--- a/lib/core/import.ml
+++ b/lib/core/import.ml
@@ -4,6 +4,16 @@ module Format = struct
   include Format
 
   let pp_of_to_string to_string ppf t = pp_print_string ppf (to_string t)
+
+  [%%if ocaml_version < (5, 2, 0)]
+
+  let pp_max_margin = Int.max_value
+
+  [%%else]
+
+  let pp_max_margin = pp_infinity - 1
+
+  [%%endif]
 end
 
 let invalid_argf fmt = Format.kasprintf invalid_arg fmt


### PR DESCRIPTION
Currently using `Message.to_string` triggers the following error:

```
  Invalid_argument "Format.pp_set_geometry: margin >= pp_infinity"
  Raised at Stdlib__Format.pp_set_geometry in file "format.ml" (inlined), line 844, characters 4-63
  Called from Grace__Diagnostic.Message.T.to_string in file "lib/core/diagnostic.ml", line 71, characters 6-68
  Called from Grace__Import.sexp_of_t_of_to_string in file "lib/core/import.ml" (inlined), line 10, characters 51-64
  Called from Grace__Diagnostic.Message.T.sexp_of_t in file "lib/core/diagnostic.ml" (inlined), line 77, characters 20-52
  Called from Grace__Diagnostic.Label.sexp_of_t in file "lib/core/diagnostic.ml", line 97, characters 6-13
  Called from Stdlib__List.map in file "list.ml", line 83, characters 15-19
  Called from Sexplib0__Sexp_conv.sexp_of_list in file "src/sexp_conv.ml", line 54, characters 39-67
  Called from Grace__Diagnostic.sexp_of_t in file "lib/core/diagnostic.ml", line 120, characters 4-10
  Called from Mlsus_error.sexp_of_t in file "lib/error/mlsus_error.ml" (inlined), line 35, characters 0-46
  Called from Mlsus_error.For_testing.catch_and_print.ppx_sexp_message in file "lib/error/mlsus_error.ml", line 184, characters 37-44
  Called from Mlsus_error.For_testing.catch_and_print in file "lib/error/mlsus_error.ml", line 184, characters 24-44
  Called from Test_parser.parse_and_print_expression in file "lib/parser/test/test_parser.ml" (inlined), line 17, characters 2-76
  Called from Test_parser.(fun) in file "lib/parser/test/test_parser.ml", line 2039, characters 2-32
  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
```

The issue is similar the problem from 666a79510f9144bfaef47e67fafc28c12814d2b1. The fix is identical