### PR TITLE
fix(renderer): renderer multi-line labels when message is empty

### DIFF
--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -234,10 +234,12 @@ let pp_line_break ~config ~severity ~ctxt ppf () =
     ctxt.multi_context
 ;;
 
+let split_lines_nonempty s = if String.is_empty s then [ "" ] else String.split_lines s
+
 (* prefixed box *)
 let pbox ~prefix pp ppf x =
   let s = Fmt.str_like ppf "%a" pp x in
-  let lines = String.split_lines s in
+  let lines = split_lines_nonempty s in
   let nlines = List.length lines in
   List.iteri lines ~f:(fun i line ->
     Fmt.pf ppf "@[<h>%s%s@]" prefix line;
@@ -247,7 +249,7 @@ let pbox ~prefix pp ppf x =
 (* prefixed-with-indent box *)
 let pwibox ~prefix pp ppf x =
   let s = Fmt.str_like ppf "%a" pp x in
-  let lines = String.split_lines s in
+  let lines = split_lines_nonempty s in
   let nlines = List.length lines in
   let nprefix = String.length prefix in
   List.iteri lines ~f:(fun i line ->

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -564,3 +564,37 @@ let%expect_test "unicode spans" =
 
     Raised: (Invalid_argument "invalid UTF-8") |}]
 ;;
+
+let%expect_test "multi-line empty messages" =
+  let source =
+    source
+      "rigid_variable_escape.ml"
+      {|
+      > let escape = fun f -> 
+      >   fun (type a) -> 
+      >     (f : a -> a)
+      > ;;
+      |}
+  in
+  let diagnostics =
+    Diagnostic.
+      [ createf
+          ~labels:[ Label.primaryf ~range:(range ~source 24 56) "" ]
+          Error
+          "generic type variable `a` escapes its scope"
+      ]
+  in
+  pr_diagnostics diagnostics;
+  [%expect
+    {|
+    error: generic type variable `a` escapes its scope
+        ┌─ rigid_variable_escape.ml:2:3
+      1 │    let escape = fun f ->
+      2 │ ╭    fun (type a) ->
+      3 │ │      (f : a -> a)
+        │ ╰─────────────────^
+      4 │    ;;
+
+    rigid_variable_escape.ml:2:3: error: generic type variable `a` escapes its scope
+    |}]
+;;


### PR DESCRIPTION
Fixes #42, #48 