### PR TITLE
Off-by-one in lines_of_labels

### DIFF
--- a/lib/ansi_renderer/snippet.ml
+++ b/lib/ansi_renderer/snippet.ml
@@ -465,7 +465,7 @@ module Of_diagnostic = struct
                 (* Inline label *)
                 Line_labels.add_inline_label line_labels label;
                 false)
-              else if Byte_index.(line_start <= label_start && label_start <= line_stop)
+              else if Byte_index.(line_start <= label_start && label_start < line_stop)
               then (
                 (* Multi-line label that starts *)
                 Line_labels.add_multi_line_label line_labels

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -589,6 +589,36 @@ let%expect_test "empty range" =
         │        ^ middle
 
     hello.txt:1:7: note: empty range
+   |}]
+;;
+
+let%expect_test "multiline label starting after newline" =
+  (* Bug #49: https://github.com/johnyob/grace/issues/49 *)
+  let content = "foo\n\nbar {\n}\n" in
+  let source : Source.t = `String { name = None; content } in
+  let diagnostics =
+    Diagnostic.
+      [ createf
+          ~labels:
+            [ Label.primaryf ~range:(range ~source 0 3) "e1"
+            ; Label.secondaryf ~range:(range ~source 5 13) "e2"
+            ]
+          Error
+          "err"
+      ]
+  in
+  pr_bad_diagnostics diagnostics;
+  [%expect
+    {|
+    error: err
+        ┌─ unknown:1:1
+      1 │    foo
+        │    ^^^ e1
+      2 │
+      3 │ ╭  bar {
+      4 │ │  }
+        │ ╰───' e2
+      5 │
     |}]
 ;;
 


### PR DESCRIPTION
Fixes #49
This ended up being just an off-by-one error. `[line_start, line_stop)` is a range where `line_stop` is excluded but `<= linestop` was used instead of `< linestop`