### PR TITLE
 Grace_ansi_renderer: fix alignment issues stemming from ansi escapes and utf8 characters

### DIFF
--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -8,21 +8,29 @@ let pp_label_styled ~(config : Config.t) ~severity ~priority pp =
   Fmt.styled_multi (Style_sheet.label config.styles priority severity) pp
 ;;
 
-let pp_label_styled_string ~config ~severity ~priority =
-  pp_label_styled ~config ~severity ~priority Fmt.string
+(** print a string as if it is length 1.
+    Useful for our unicode characters which are still visually length 1 *)
+let pp_single_char ppf = Format.pp_print_as ppf 1
+
+let pp_label_styled_char ~config ~severity ~priority =
+  pp_label_styled ~config ~severity ~priority pp_single_char
 ;;
 
 module Chars = struct
   let pp_source_border_left ~(config : Config.t) ppf () =
     Fmt.(
-      styled_multi config.styles.source_border string ppf config.chars.source_border_left)
+      styled_multi
+        config.styles.source_border
+        pp_single_char
+        ppf
+        config.chars.source_border_left)
   ;;
 
   let pp_source_border_left_break ~(config : Config.t) ppf () =
     Fmt.(
       styled_multi
         config.styles.source_border
-        string
+        pp_single_char
         ppf
         config.chars.source_border_left_break)
   ;;
@@ -33,19 +41,19 @@ module Chars = struct
       | Priority.Primary -> config.chars.single_primary_caret
       | Secondary -> config.chars.single_secondary_caret
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret
+    pp_label_styled_char ~config ~severity ~priority ppf caret
   ;;
 
   let pp_pointer_left ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.pointer_left
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.pointer_left
   ;;
 
   let pp_multi_top ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.multi_top
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.multi_top
   ;;
 
   let pp_multi_bottom ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.multi_bottom
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.multi_bottom
   ;;
 
   let pp_multi_caret_start ~(config : Config.t) ~severity ~priority ppf () =
@@ -54,7 +62,7 @@ module Chars = struct
       | Priority.Primary -> config.chars.multi_primary_caret_start
       | Secondary -> config.chars.multi_secondary_caret_start
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret_start
+    pp_label_styled_char ~config ~severity ~priority ppf caret_start
   ;;
 
   let pp_multi_caret_end ~(config : Config.t) ~severity ~priority ppf () =
@@ -63,7 +71,7 @@ module Chars = struct
       | Priority.Primary -> config.chars.multi_primary_caret_end
       | Secondary -> config.chars.multi_secondary_caret_end
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret_end
+    pp_label_styled_char ~config ~severity ~priority ppf caret_end
   ;;
 
   let pp_snippet_start ~(config : Config.t) ppf () =
@@ -71,7 +79,7 @@ module Chars = struct
   ;;
 
   let pp_note_bullet ~(config : Config.t) ppf () =
-    Fmt.styled_multi config.styles.note_bullet Fmt.string ppf config.chars.note_bullet
+    Fmt.styled_multi config.styles.note_bullet pp_single_char ppf config.chars.note_bullet
   ;;
 end
 
@@ -144,7 +152,7 @@ let pp_multi_vertline ~(config : Config.t) ~severity ~priority ppf kind =
     | `Vertical -> config.chars.multi_left
     | `Bottom -> config.chars.multi_bottom_left
   in
-  pp_label_styled_string ~config ~severity ~priority ppf gutter
+  pp_label_styled_char ~config ~severity ~priority ppf gutter
 ;;
 
 let pp_multi_underline ~(config : Config.t) ~severity ~priority ppf kind =
@@ -200,7 +208,7 @@ let pp_source_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
     match segment.stag with
     | Some { priority = Primary; _ } ->
       (* If primary, style the content *)
-      pp_label_styled_string ~config ~severity ~priority:Primary ppf content
+      pp_label_styled ~config ~severity ~priority:Primary Fmt.string ppf content
     | _ ->
       (* Otherwise, simply print the content *)
       Fmt.string ppf content
@@ -244,11 +252,10 @@ let pbox ~prefix pp ppf x =
 ;;
 
 (* prefixed-with-indent box *)
-let pwibox ~prefix pp ppf x =
+let pwibox ~prefix ~nprefix pp ppf x =
   let s = Fmt.str_like ppf "%a" pp x in
   let lines = split_lines_nonempty s in
   let nlines = List.length lines in
-  let nprefix = String.length prefix in
   List.iteri lines ~f:(fun i line ->
     if i = 0
     then Fmt.pf ppf "@[<h>%s%s@]" prefix line
@@ -283,16 +290,15 @@ module Multi_line_label = struct
   ;;
 
   let pp_bottom ~config ~severity ppf (width, priority, label) =
-    let prefix =
-      Fmt.str_like
-        ppf
-        "%a%a "
-        (pp_underlines ~config ~severity ~priority ~width)
-        `Bottom
-        (Chars.pp_multi_caret_end ~config ~severity ~priority)
-        ()
-    in
-    pwibox ~prefix (pp_message ~config ~severity ~priority) ppf label
+    Fmt.pf
+      ppf
+      "%a%a %a"
+      (pp_underlines ~config ~severity ~priority ~width)
+      `Bottom
+      (Chars.pp_multi_caret_end ~config ~severity ~priority)
+      ()
+      (pp_message ~config ~severity ~priority)
+      label
   ;;
 
   let pp_content_top ~ctxt ~(top : Multi_line_label.t option) pp ppf x =
@@ -476,15 +482,17 @@ module Inline_labels = struct
 end
 
 let pp_multi_line_label ~config ~severity ~ctxt ppf multi_line_label =
-  Fmt.pf
-    ppf
-    "@[<h>%*s %a %a@]"
-    ctxt.line_num_width
-    ""
-    (Chars.pp_source_border_left ~config)
-    ()
-    (Multi_line_label.pp ~config ~severity ~ctxt)
-    multi_line_label
+  (* equivalent to lbox but without multi_line, as that is handled internally *)
+  let prefix =
+    Fmt.str_like
+      ppf
+      "%*s %a "
+      ctxt.line_num_width
+      ""
+      (Chars.pp_source_border_left ~config)
+      ()
+  in
+  pbox ~prefix (Multi_line_label.pp ~config ~severity ~ctxt) ppf multi_line_label
 ;;
 
 let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
@@ -611,6 +619,7 @@ let pp_note ~config ~line_num_width ppf note =
   pwibox
     ~prefix:
       (Fmt.str_like ppf "%*s %a " line_num_width "" (Chars.pp_note_bullet ~config) ())
+    ~nprefix:(line_num_width + 3)
     Message.pp
     ppf
     note

--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -127,9 +127,10 @@ module Multi_context = struct
     (* Set gutter to `Top *)
     t.gutters.(gutter) <- Some (priority, `Top top_kind);
     (* Execute 'prologue' for multi-line label *)
-    prologue ();
+    let r = prologue () in
     (* Set gutter to `Vertical *)
-    t.gutters.(gutter) <- Some (priority, `Vertical)
+    t.gutters.(gutter) <- Some (priority, `Vertical);
+    r
   ;;
 
   let free t ~multi_id epilogue =
@@ -138,10 +139,11 @@ module Multi_context = struct
     (* Set gutter to `Bottom *)
     t.gutters.(gutter) <- Some (priority, `Bottom);
     (* Execute 'epilogue' for multi-line label *)
-    epilogue ();
+    let r = epilogue () in
     (* Remove bindings for multi-line label *)
     t.gutters.(gutter) <- None;
-    Hashtbl.remove t.bindings multi_id
+    Hashtbl.remove t.bindings multi_id;
+    r
   ;;
 end
 
@@ -264,8 +266,9 @@ let pwibox ~prefix ~nprefix pp ppf x =
 ;;
 
 (* line box *)
-let lbox ~config ~severity ~ctxt pp ppf x =
-  let prefix =
+
+let lbox ?(prologue = fun f -> f ()) ~config ~severity ~ctxt pp ppf x =
+  let make_prefix () =
     Fmt.str_like
       ppf
       "%*s %a %a"
@@ -276,7 +279,17 @@ let lbox ~config ~severity ~ctxt pp ppf x =
       (pp_multi_lines ~config ~severity)
       ctxt.multi_context
   in
-  pbox ~prefix pp ppf x
+  (* when printing a multi-line label, the first line may have a different prefix than the others *)
+  let prefix = prologue make_prefix in
+  let prefix2 = make_prefix () in
+  let s = Fmt.str_like ppf "%a" pp x in
+  let lines = split_lines_nonempty s in
+  let nlines = List.length lines in
+  List.iteri lines ~f:(fun i line ->
+    if i = 0
+    then Fmt.pf ppf "@[<h>%s%s@]" prefix line
+    else Fmt.pf ppf "@[<h>%s%s@]" prefix2 line;
+    if i <> nlines - 1 then Fmt.newline ppf ())
 ;;
 
 module Multi_line_label = struct
@@ -312,22 +325,23 @@ module Multi_line_label = struct
     | None -> pp ppf x
   ;;
 
-  let pp ~config ~severity ~ctxt ppf (multi_line_label : Multi_line_label.t) =
+  let with_multi ~ctxt (multi_line_label : Multi_line_label.t) f =
     match multi_line_label with
-    | Bottom { id; stop; priority; label } ->
-      Multi_context.free ctxt.multi_context ~multi_id:id
-      @@ fun () ->
-      pp_multi_lines ~config ~severity ppf ctxt.multi_context;
+    | Bottom { id; _ } -> Multi_context.free ctxt.multi_context ~multi_id:id f
+    | Top { id; priority; _ } ->
+      Multi_context.def ctxt.multi_context ~multi_id:id ~top_kind:`Non_unique ~priority f
+  ;;
+
+  let pp ~config ~severity ppf (multi_line_label : Multi_line_label.t) =
+    match multi_line_label with
+    | Bottom { stop; priority; label; _ } ->
       pp_bottom
         ~config
         ~severity
         ppf
         (* [-2] since we want a [-1] offset and [stop] is a column number (starting at 1) *)
         ((stop :> int) - 2, priority, label)
-    | Top { id; start; priority } ->
-      Multi_context.def ctxt.multi_context ~multi_id:id ~top_kind:`Non_unique ~priority
-      @@ fun () ->
-      pp_multi_lines ~config ~severity ppf ctxt.multi_context;
+    | Top { start; priority; _ } ->
       (* [-1] since [start] is a column number (starting at 1) *)
       pp_top ~config ~severity ppf ((start :> int) - 1, priority)
   ;;
@@ -481,20 +495,6 @@ module Inline_labels = struct
   ;;
 end
 
-let pp_multi_line_label ~config ~severity ~ctxt ppf multi_line_label =
-  (* equivalent to lbox but without multi_line, as that is handled internally *)
-  let prefix =
-    Fmt.str_like
-      ppf
-      "%*s %a "
-      ctxt.line_num_width
-      ""
-      (Chars.pp_source_border_left ~config)
-      ()
-  in
-  pbox ~prefix (Multi_line_label.pp ~config ~severity ~ctxt) ppf multi_line_label
-;;
-
 let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
   (* Convert segments to inline labels *)
   let inline_labels = Inline_labels.of_segments line.segments in
@@ -535,7 +535,14 @@ let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
   (* Print multi-line labels (if any) *)
   List.iter multi_line_labels ~f:(fun multi_line_label ->
     Fmt.newline ppf ();
-    pp_multi_line_label ~config ~severity ~ctxt ppf multi_line_label)
+    lbox
+      ~prologue:(Multi_line_label.with_multi ~ctxt multi_line_label)
+      ~config
+      ~severity
+      ~ctxt
+      (Multi_line_label.pp ~config ~severity)
+      ppf
+      multi_line_label)
 ;;
 
 let pp_locus ~source ppf (line_num, col_num) =

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1008,7 +1008,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 │ │  };
         │ ╰────' e2:
         │          new line of error 2
-        │ unboxed new line of error 2
+        │    unboxed new line of error 2
       5 │    baz
 
     unknown:1:1: error: err
@@ -1023,7 +1023,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 | |  };
         | \----' e2:
         |          new line of error 2
-        | unboxed new line of error 2
+        |    unboxed new line of error 2
       5 |    baz
 
     unknown:1:1: error: err
@@ -1036,7 +1036,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
           "e3: encapsulates everything"
         :: diagnostic.labels
     };
-  [%expect {|
+  [%expect
+    {|
     error: err
         ┌─ unknown:1:1
       1 │ ╭    foo
@@ -1047,8 +1048,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 │ │ ╭  bar {
       4 │ │ │  };
         │ │ ╰────' e2:
-        │            new line of error 2
-        │ unboxed new line of error 2
+        │ │          new line of error 2
+        │ │    unboxed new line of error 2
       5 │ │    baz
         │ ╰──────' e3: encapsulates everything
 
@@ -1063,8 +1064,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 | | /  bar {
       4 | | |  };
         | | \----' e2:
-        |            new line of error 2
-        | unboxed new line of error 2
+        | |          new line of error 2
+        | |    unboxed new line of error 2
       5 | |    baz
         | \------' e3: encapsulates everything
 

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1,5 +1,6 @@
 open! Core
 open! Grace
+open! Grace_std
 open Diagnostic
 
 let source name content : Source.t =
@@ -10,19 +11,61 @@ let range ~source start stop =
   Range.create ~source (Byte_index.of_int start) (Byte_index.of_int stop)
 ;;
 
-let pr_diagnostics ?(config = Grace_ansi_renderer.Config.default) diagnostics =
+(* This code is Copyright (c) 2017 The b0 programmers.
+  SPDX-License-Identifier: ISC *)
+let strip_ansi_escapes s =
+  let len = String.length s in
+  let b = Buffer.create len in
+  let max = len - 1 in
+  let flush start stop =
+    if start < 0 || start > max
+    then ()
+    else Stdlib.Buffer.add_substring b s start (stop - start + 1)
+  in
+  let rec skip_esc i =
+    if i > max
+    then loop i i
+    else (
+      let k = i + 1 in
+      if s.[i] = 'm' then loop k k else skip_esc k)
+  and loop start i =
+    match i > max with
+    | true ->
+      if Buffer.length b = len
+      then s
+      else (
+        flush start max;
+        Buffer.contents b)
+    | false ->
+      (match s.[i] with
+       | '\x1B' ->
+         flush start (i - 1);
+         skip_esc (i + 1)
+       | _ -> loop start (i + 1))
+  in
+  loop 0 0
+;;
+
+let pr_diagnostics
+      ?(config = Grace_ansi_renderer.Config.default)
+      ?(ansi = false)
+      diagnostics
+  =
   let open Grace_ansi_renderer in
-  (* Disable colors for tests (since expect tests don't support ANSI colors) *)
-  let config = { config with use_ansi = Some false } in
-  Fmt.(
-    list
-      ~sep:(fun ppf () -> pf ppf "@.@.@.")
-      (fun ppf diagnostic ->
-         pp_diagnostic ~config ppf diagnostic;
-         pf ppf "@.@.";
-         pp_compact_diagnostic ~config ppf diagnostic))
-    Fmt.stdout
-    diagnostics
+  let config = { config with use_ansi = Some ansi } in
+  let output =
+    Fmt.(str_like stdout)
+      "%a"
+      Fmt.(
+        list
+          ~sep:(fun ppf () -> pf ppf "@.@.@.")
+          (fun ppf diagnostic ->
+             pp_diagnostic ~config ppf diagnostic;
+             pf ppf "@.@.";
+             pp_compact_diagnostic ~config ppf diagnostic))
+      diagnostics
+  in
+  print_endline (strip_ansi_escapes output)
 ;;
 
 let pr_bad_diagnostics ?(config = Grace_ansi_renderer.Config.default) diagnostics =
@@ -85,7 +128,7 @@ let%expect_test "same_line" =
   let source =
     source
       "one_line.rs"
-      {|  
+      {|
       > fn main() {
       >     let mut v = vec![Some("foo"), Some("bar")];
       >     v.push(v.pop().unwrap());
@@ -154,7 +197,7 @@ let%expect_test "overlapping" =
       "typeck_type_placeholder_item.rs"
       {|
       > fn fn_test1() -> _ { 5 }
-      > fn fn_test2(x: i32) -> (_, _) { (x, x) }  
+      > fn fn_test2(x: i32) -> (_, _) { (x, x) }
       |}
   in
   let s3 =
@@ -651,8 +694,8 @@ let%expect_test "multi-line empty messages" =
     source
       "rigid_variable_escape.ml"
       {|
-      > let escape = fun f -> 
-      >   fun (type a) -> 
+      > let escape = fun f ->
+      >   fun (type a) ->
       >     (f : a -> a)
       > ;;
       |}
@@ -920,5 +963,67 @@ let%expect_test "num_contextual_lines = 2 and enable_inline_contextual_lines = t
       4 │  line 4
 
     inline.ml:2:1: error: Testing inline labels without contextual lines
+|}]
+;;
+
+let%expect_test "label with multiple lines and ansi formatting" =
+  (* Bug #71: https://github.com/johnyob/grace/issues/71*)
+  let compare diagnostic =
+    pr_diagnostics ~ansi:true [ diagnostic ];
+    (* check consistency with non-unicode, non-ansi *)
+    pr_diagnostics
+      ~ansi:false
+      ~config:Grace_ansi_renderer.Config.{ default with chars = Chars.ascii }
+      [ diagnostic ]
+  in
+  let content = "foo\n\nbar {\n};\nbaz" in
+  let source : Source.t = `String { name = None; content } in
+  let diagnostic =
+    Diagnostic.(
+      createf
+        ~labels:
+          [ Label.primaryf
+              ~range:(range ~source 0 3)
+              "@[<v2>e1:@ new line of error1@]@ unboxed new line of error 1"
+          ; Label.secondaryf
+              ~range:(range ~source 5 14)
+              "@[<v2>e2:@ new line of error 2@]@ unboxed new line of error 2"
+          ]
+        Error
+        "err")
+  in
+  compare diagnostic;
+  [%expect
+    {|
+    error: err
+        ┌─ unknown:1:1
+      1 │    foo
+        │    ^^^ e1:
+        │          new line of error1
+        │    unboxed new line of error 1
+      2 │
+      3 │ ╭  bar {
+      4 │ │  };
+        │ ╰────' e2:
+                                         new line of error 2
+                                       unboxed new line of error 2
+      5 │    baz
+
+    unknown:1:1: error: err
+    error: err
+        --> unknown:1:1
+      1 |    foo
+        |    ^^^ e1:
+        |          new line of error1
+        |    unboxed new line of error 1
+      2 |
+      3 | /  bar {
+      4 | |  };
+        | \----' e2:
+          new line of error 2
+        unboxed new line of error 2
+      5 |    baz
+
+    unknown:1:1: error: err
     |}]
 ;;

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1027,5 +1027,47 @@ let%expect_test "label with multiple lines and ansi formatting" =
       5 |    baz
 
     unknown:1:1: error: err
+    |}];
+  compare
+    { diagnostic with
+      labels =
+        Diagnostic.Label.secondaryf
+          ~range:(range ~source 0 17)
+          "e3: encapsulates everything"
+        :: diagnostic.labels
+    };
+  [%expect {|
+    error: err
+        ┌─ unknown:1:1
+      1 │ ╭    foo
+        │ │    ^^^ e1:
+        │ │          new line of error1
+        │ │    unboxed new line of error 1
+      2 │ │
+      3 │ │ ╭  bar {
+      4 │ │ │  };
+        │ │ ╰────' e2:
+        │            new line of error 2
+        │ unboxed new line of error 2
+      5 │ │    baz
+        │ ╰──────' e3: encapsulates everything
+
+    unknown:1:1: error: err
+    error: err
+        --> unknown:1:1
+      1 | /    foo
+        | |    ^^^ e1:
+        | |          new line of error1
+        | |    unboxed new line of error 1
+      2 | |
+      3 | | /  bar {
+      4 | | |  };
+        | | \----' e2:
+        |            new line of error 2
+        | unboxed new line of error 2
+      5 | |    baz
+        | \------' e3: encapsulates everything
+
+    unknown:1:1: error: err
     |}]
 ;;

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1,6 +1,5 @@
 open! Core
 open! Grace
-open! Grace_std
 open Diagnostic
 
 let source name content : Source.t =
@@ -11,6 +10,8 @@ let range ~source start stop =
   Range.create ~source (Byte_index.of_int start) (Byte_index.of_int stop)
 ;;
 
+(* Useful for testing, since we want to be able to show that turning on ANSI
+ doesn't break the alignment of other things! *)
 (* This code is Copyright (c) 2017 The b0 programmers.
   SPDX-License-Identifier: ISC *)
 let strip_ansi_escapes s =
@@ -27,7 +28,7 @@ let strip_ansi_escapes s =
     then loop i i
     else (
       let k = i + 1 in
-      if s.[i] = 'm' then loop k k else skip_esc k)
+      if Char.equal s.[i] 'm' then loop k k else skip_esc k)
   and loop start i =
     match i > max with
     | true ->
@@ -557,7 +558,8 @@ let%expect_test "unicode" =
        - unadjusted
        - vectorcall
        - win64
-       - x86-interrupt |}]
+       - x86-interrupt
+    |}]
 ;;
 
 let%expect_test "unicode spans" =
@@ -1005,8 +1007,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 │ ╭  bar {
       4 │ │  };
         │ ╰────' e2:
-                                         new line of error 2
-                                       unboxed new line of error 2
+        │          new line of error 2
+        │ unboxed new line of error 2
       5 │    baz
 
     unknown:1:1: error: err
@@ -1020,8 +1022,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 | /  bar {
       4 | |  };
         | \----' e2:
-          new line of error 2
-        unboxed new line of error 2
+        |          new line of error 2
+        | unboxed new line of error 2
       5 |    baz
 
     unknown:1:1: error: err


### PR DESCRIPTION
Closes #71

The relevant part of the test is the `new line of error`. Before this fix (e.g. in b061e5fa9a3c1eae997b31aaf907e8e82664c7f9), the ansi/unicode version was massively over-indented. 