### PR TITLE
feat(json_conv): Specify the type as the narrower Yojson.Basic.t

### DIFF
--- a/examples/main.ml
+++ b/examples/main.ml
@@ -54,7 +54,7 @@ let () =
   | [| _; "--json" |] ->
     Format.printf
       "%a@."
-      (Yojson.Safe.pretty_print ~std:true)
+      (Yojson.Basic.pretty_print ~std:true)
       (Grace_json_conv.json_of_diagnostic ~code_to_string diagnostic)
   | _ ->
     Format.printf

--- a/lib/json_conv/grace_json_conv.ml
+++ b/lib/json_conv/grace_json_conv.ml
@@ -10,7 +10,7 @@ let json_of_byte_index ~in_ (idx : Byte_index.t) =
   `Assoc [ "line", line_json; "column", column_json ]
 ;;
 
-let json_of_range (r : Range.t) : Yojson.Safe.t =
+let json_of_range (r : Range.t) : Yojson.Basic.t =
   let sd = Grace_source_reader.open_source (Range.source r) in
   let vals =
     [ "start", json_of_byte_index ~in_:sd (Range.start r)
@@ -22,11 +22,11 @@ let json_of_range (r : Range.t) : Yojson.Safe.t =
   | None -> `Assoc vals
 ;;
 
-let json_of_message (message : Diagnostic.Message.t) : Yojson.Safe.t =
+let json_of_message (message : Diagnostic.Message.t) : Yojson.Basic.t =
   `String (Diagnostic.Message.to_string message)
 ;;
 
-let json_of_label ({ range; priority; message } : Diagnostic.Label.t) : Yojson.Safe.t =
+let json_of_label ({ range; priority; message } : Diagnostic.Label.t) : Yojson.Basic.t =
   `Assoc
     Diagnostic.
       [ "range", json_of_range range
@@ -38,7 +38,7 @@ let json_of_label ({ range; priority; message } : Diagnostic.Label.t) : Yojson.S
 let json_of_diagnostic
       ?code_to_string
       ({ severity; message; notes; labels; code } : 'a Diagnostic.t)
-  : Yojson.Safe.t
+  : Yojson.Basic.t
   =
   Grace_source_reader.with_reader
   @@ fun () ->

--- a/lib/json_conv/grace_json_conv.mli
+++ b/lib/json_conv/grace_json_conv.mli
@@ -23,4 +23,4 @@
 val json_of_diagnostic
   :  ?code_to_string:('code -> string)
   -> 'code Grace.Diagnostic.t
-  -> Yojson.Safe.t
+  -> Yojson.Basic.t

--- a/test/json_conv/test_json_conv.ml
+++ b/test/json_conv/test_json_conv.ml
@@ -12,7 +12,7 @@ let range ~source start stop =
 
 let pr_diagnostics diagnostics =
   let jsons = List.map diagnostics ~f:Grace_json_conv.json_of_diagnostic in
-  Yojson.Safe.pretty_print Fmt.stdout (`List jsons)
+  Yojson.Basic.pretty_print Fmt.stdout (`List jsons)
 ;;
 
 let pr_bad_diagnostics diagnostics =
@@ -21,7 +21,7 @@ let pr_bad_diagnostics diagnostics =
       ~sep:(fun ppf () -> pf ppf "@.@.")
       (fun ppf diagnostic ->
          try
-           Yojson.Safe.pretty_print ppf (Grace_json_conv.json_of_diagnostic diagnostic)
+           Yojson.Basic.pretty_print ppf (Grace_json_conv.json_of_diagnostic diagnostic)
          with
          | exn -> Fmt.pf ppf "Raised: %s" (Exn.to_string exn)))
     Fmt.stdout


### PR DESCRIPTION
This was a simple mistake by me in #84, I often get mixed up between the various Yojson modules and thought 'Safe' was the smallest one, but it is not, 'Basic' is. 

This makes the type easier to consume downstream.