### PR TITLE
fix(ansi_renderer): fix alignment issues stemming from ansi escapes and utf8 characters

### DIFF
--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -127,9 +127,10 @@ module Multi_context = struct
     (* Set gutter to `Top *)
     t.gutters.(gutter) <- Some (priority, `Top top_kind);
     (* Execute 'prologue' for multi-line label *)
-    prologue ();
+    let r = prologue () in
     (* Set gutter to `Vertical *)
-    t.gutters.(gutter) <- Some (priority, `Vertical)
+    t.gutters.(gutter) <- Some (priority, `Vertical);
+    r
   ;;
 
   let free t ~multi_id epilogue =
@@ -138,10 +139,11 @@ module Multi_context = struct
     (* Set gutter to `Bottom *)
     t.gutters.(gutter) <- Some (priority, `Bottom);
     (* Execute 'epilogue' for multi-line label *)
-    epilogue ();
+    let r = epilogue () in
     (* Remove bindings for multi-line label *)
     t.gutters.(gutter) <- None;
-    Hashtbl.remove t.bindings multi_id
+    Hashtbl.remove t.bindings multi_id;
+    r
   ;;
 end
 
@@ -239,44 +241,43 @@ let pp_line_break ~config ~severity ~ctxt ppf () =
     ctxt.multi_context
 ;;
 
+let pp_line_prefix ~config ~severity ~ctxt ppf () =
+  Fmt.pf
+    ppf
+    "%*s %a %a"
+    ctxt.line_num_width
+    ""
+    (Chars.pp_source_border_left ~config)
+    ()
+    (pp_multi_lines ~config ~severity)
+    ctxt.multi_context
+;;
+
 let split_lines_nonempty s = if String.is_empty s then [ "" ] else String.split_lines s
+
+(* Grace defines a series of custom boxes that enforce prefixes at newlines. *)
 
 (* prefixed box *)
 let pbox ~prefix pp ppf x =
   let s = Fmt.str_like ppf "%a" pp x in
-  let lines = split_lines_nonempty s in
-  let nlines = List.length lines in
-  List.iteri lines ~f:(fun i line ->
-    Fmt.pf ppf "@[<h>%s%s@]" prefix line;
-    if i <> nlines - 1 then Fmt.newline ppf ())
+  match split_lines_nonempty s with
+  | [] -> assert false
+  | first_line :: rest ->
+    Fmt.pf ppf "@[<h>%s@]" first_line;
+    List.iter rest ~f:(fun line ->
+      Fmt.newline ppf ();
+      Fmt.pf ppf "@[<h>%a%s@]" prefix () line)
 ;;
 
-(* prefixed-with-indent box *)
-let pwibox ~prefix ~nprefix pp ppf x =
-  let s = Fmt.str_like ppf "%a" pp x in
-  let lines = split_lines_nonempty s in
-  let nlines = List.length lines in
-  List.iteri lines ~f:(fun i line ->
-    if i = 0
-    then Fmt.pf ppf "@[<h>%s%s@]" prefix line
-    else Fmt.pf ppf "@[<h>%*s%s@]" nprefix "" line;
-    if i <> nlines - 1 then Fmt.newline ppf ())
+let prefixed_pbox ~prefix pp ppf x = Fmt.pf ppf "%a%a" prefix () (pbox ~prefix pp) x
+
+let prefixed_vbox ~prefix ~indent pp ppf x =
+  Fmt.pf ppf "%s%a" prefix Fmt.(vbox ~indent pp) x
 ;;
 
 (* line box *)
 let lbox ~config ~severity ~ctxt pp ppf x =
-  let prefix =
-    Fmt.str_like
-      ppf
-      "%*s %a %a"
-      ctxt.line_num_width
-      ""
-      (Chars.pp_source_border_left ~config)
-      ()
-      (pp_multi_lines ~config ~severity)
-      ctxt.multi_context
-  in
-  pbox ~prefix pp ppf x
+  pbox ~prefix:(pp_line_prefix ~config ~severity ~ctxt) pp ppf x
 ;;
 
 module Multi_line_label = struct
@@ -284,21 +285,19 @@ module Multi_line_label = struct
     Fmt.repeat ~width (pp_multi_underline ~config ~severity ~priority)
   ;;
 
-  let pp_top ~config ~severity ppf (width, priority) =
+  let pp_top_underlines ~config ~severity ~priority ~width ppf () =
     pp_underlines ~config ~severity ~priority ~width ppf (`Top `Non_unique);
     Chars.pp_multi_caret_start ~config ~severity ~priority ppf ()
   ;;
 
-  let pp_bottom ~config ~severity ppf (width, priority, label) =
+  let pp_bottom_underlines ~config ~severity ~priority ~width ppf () =
     Fmt.pf
       ppf
-      "%a%a %a"
+      "%a%a"
       (pp_underlines ~config ~severity ~priority ~width)
       `Bottom
       (Chars.pp_multi_caret_end ~config ~severity ~priority)
       ()
-      (pp_message ~config ~severity ~priority)
-      label
   ;;
 
   let pp_content_top ~ctxt ~(top : Multi_line_label.t option) pp ppf x =
@@ -315,21 +314,32 @@ module Multi_line_label = struct
   let pp ~config ~severity ~ctxt ppf (multi_line_label : Multi_line_label.t) =
     match multi_line_label with
     | Bottom { id; stop; priority; label } ->
-      Multi_context.free ctxt.multi_context ~multi_id:id
-      @@ fun () ->
-      pp_multi_lines ~config ~severity ppf ctxt.multi_context;
-      pp_bottom
-        ~config
-        ~severity
-        ppf
-        (* [-2] since we want a [-1] offset and [stop] is a column number (starting at 1) *)
-        ((stop :> int) - 2, priority, label)
+      (* [-2] since we want a [-1] offset and [stop] is a column number (starting at 1) *)
+      let width = (stop :> int) - 2 in
+      (* print leading underline prefix *)
+      (Multi_context.free ctxt.multi_context ~multi_id:id
+       @@ fun () -> pp_multi_lines ~config ~severity ppf ctxt.multi_context);
+      let pp_bottom ppf () =
+        Fmt.pf
+          ppf
+          "%a @[<v>%a@]"
+          (pp_bottom_underlines ~config ~severity ~priority ~width)
+          ()
+          (pp_message ~config ~severity ~priority)
+          label
+      in
+      (* lbox the underlines and message. The underlines are necessary 
+         since the lbox prints the prefix *upto* the underlines. 
+         In particular, it is responsible for printing any multi-line 
+         prefix. *)
+      lbox ~config ~severity ~ctxt pp_bottom ppf ()
     | Top { id; start; priority } ->
-      Multi_context.def ctxt.multi_context ~multi_id:id ~top_kind:`Non_unique ~priority
-      @@ fun () ->
-      pp_multi_lines ~config ~severity ppf ctxt.multi_context;
       (* [-1] since [start] is a column number (starting at 1) *)
-      pp_top ~config ~severity ppf ((start :> int) - 1, priority)
+      let width = (start :> int) - 1 in
+      (* print leading underline prefix *)
+      (Multi_context.def ctxt.multi_context ~multi_id:id ~top_kind:`Non_unique ~priority
+       @@ fun () -> pp_multi_lines ~config ~severity ppf ctxt.multi_context);
+      pp_top_underlines ~config ~severity ~priority ~width ppf ()
   ;;
 end
 
@@ -420,7 +430,11 @@ module Inline_labels = struct
         loop Column_number.(add offset 1) (pointers ^ str_pointer_left priority) segments;
         Fmt.newline ppf ();
         (* Print the messages *)
-        pbox ~prefix:pointers (pp_messages ~priority) ppf messages
+        prefixed_pbox
+          ~prefix:Fmt.(const string pointers)
+          (pp_messages ~priority)
+          ppf
+          messages
     in
     loop Column_number.initial "" segments
   ;;
@@ -482,17 +496,27 @@ module Inline_labels = struct
 end
 
 let pp_multi_line_label ~config ~severity ~ctxt ppf multi_line_label =
-  (* equivalent to lbox but without multi_line, as that is handled internally *)
-  let prefix =
-    Fmt.str_like
-      ppf
-      "%*s %a "
-      ctxt.line_num_width
-      ""
-      (Chars.pp_source_border_left ~config)
-      ()
-  in
-  pbox ~prefix (Multi_line_label.pp ~config ~severity ~ctxt) ppf multi_line_label
+  (* We omit printing the multi lines (which would occur if using [pp_line_prefix]) 
+     since this is done in [Multi_line_label.pp]. *)
+  Fmt.pf
+    ppf
+    "@[<h>%*s %a %a@]"
+    ctxt.line_num_width
+    ""
+    (Chars.pp_source_border_left ~config)
+    ()
+    (Multi_line_label.pp ~config ~severity ~ctxt)
+    multi_line_label
+;;
+
+let pp_inline_labels ~config ~severity ~ctxt ppf inline_labels =
+  Fmt.pf
+    ppf
+    "@[<h>%a%a@]"
+    (pp_line_prefix ~config ~severity ~ctxt)
+    ()
+    (lbox ~config ~severity ~ctxt (Inline_labels.pp ~config ~severity))
+    inline_labels
 ;;
 
 let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
@@ -531,7 +555,7 @@ let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
   if not (Inline_labels.is_empty inline_labels)
   then (
     Fmt.newline ppf ();
-    lbox ~config ~severity ~ctxt (Inline_labels.pp ~config ~severity) ppf inline_labels);
+    pp_inline_labels ~config ~severity ~ctxt ppf inline_labels);
   (* Print multi-line labels (if any) *)
   List.iter multi_line_labels ~f:(fun multi_line_label ->
     Fmt.newline ppf ();
@@ -616,12 +640,15 @@ let pp_header ~config ~code_to_string ~severity ~code ppf message =
 ;;
 
 let pp_note ~config ~line_num_width ppf note =
-  pwibox
-    ~prefix:
-      (Fmt.str_like ppf "%*s %a " line_num_width "" (Chars.pp_note_bullet ~config) ())
-    ~nprefix:(line_num_width + 3)
-    Message.pp
+  let note_prefix ppf () = Fmt.pf ppf "%*s" (line_num_width + 3) "" in
+  Fmt.pf
     ppf
+    "@[<h>%*s %a %a@]"
+    line_num_width
+    ""
+    (Chars.pp_note_bullet ~config)
+    ()
+    (pbox ~prefix:note_prefix Message.pp)
     note
 ;;
 

--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -8,21 +8,29 @@ let pp_label_styled ~(config : Config.t) ~severity ~priority pp =
   Fmt.styled_multi (Style_sheet.label config.styles priority severity) pp
 ;;
 
-let pp_label_styled_string ~config ~severity ~priority =
-  pp_label_styled ~config ~severity ~priority Fmt.string
+(** print a string as if it is length 1.
+    Useful for our unicode characters which are still visually length 1 *)
+let pp_single_char ppf = Format.pp_print_as ppf 1
+
+let pp_label_styled_char ~config ~severity ~priority =
+  pp_label_styled ~config ~severity ~priority pp_single_char
 ;;
 
 module Chars = struct
   let pp_source_border_left ~(config : Config.t) ppf () =
     Fmt.(
-      styled_multi config.styles.source_border string ppf config.chars.source_border_left)
+      styled_multi
+        config.styles.source_border
+        pp_single_char
+        ppf
+        config.chars.source_border_left)
   ;;
 
   let pp_source_border_left_break ~(config : Config.t) ppf () =
     Fmt.(
       styled_multi
         config.styles.source_border
-        string
+        pp_single_char
         ppf
         config.chars.source_border_left_break)
   ;;
@@ -33,19 +41,19 @@ module Chars = struct
       | Priority.Primary -> config.chars.single_primary_caret
       | Secondary -> config.chars.single_secondary_caret
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret
+    pp_label_styled_char ~config ~severity ~priority ppf caret
   ;;
 
   let pp_pointer_left ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.pointer_left
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.pointer_left
   ;;
 
   let pp_multi_top ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.multi_top
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.multi_top
   ;;
 
   let pp_multi_bottom ~(config : Config.t) ~severity ~priority ppf () =
-    pp_label_styled_string ~config ~severity ~priority ppf config.chars.multi_bottom
+    pp_label_styled_char ~config ~severity ~priority ppf config.chars.multi_bottom
   ;;
 
   let pp_multi_caret_start ~(config : Config.t) ~severity ~priority ppf () =
@@ -54,7 +62,7 @@ module Chars = struct
       | Priority.Primary -> config.chars.multi_primary_caret_start
       | Secondary -> config.chars.multi_secondary_caret_start
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret_start
+    pp_label_styled_char ~config ~severity ~priority ppf caret_start
   ;;
 
   let pp_multi_caret_end ~(config : Config.t) ~severity ~priority ppf () =
@@ -63,7 +71,7 @@ module Chars = struct
       | Priority.Primary -> config.chars.multi_primary_caret_end
       | Secondary -> config.chars.multi_secondary_caret_end
     in
-    pp_label_styled_string ~config ~severity ~priority ppf caret_end
+    pp_label_styled_char ~config ~severity ~priority ppf caret_end
   ;;
 
   let pp_snippet_start ~(config : Config.t) ppf () =
@@ -71,7 +79,7 @@ module Chars = struct
   ;;
 
   let pp_note_bullet ~(config : Config.t) ppf () =
-    Fmt.styled_multi config.styles.note_bullet Fmt.string ppf config.chars.note_bullet
+    Fmt.styled_multi config.styles.note_bullet pp_single_char ppf config.chars.note_bullet
   ;;
 end
 
@@ -144,7 +152,7 @@ let pp_multi_vertline ~(config : Config.t) ~severity ~priority ppf kind =
     | `Vertical -> config.chars.multi_left
     | `Bottom -> config.chars.multi_bottom_left
   in
-  pp_label_styled_string ~config ~severity ~priority ppf gutter
+  pp_label_styled_char ~config ~severity ~priority ppf gutter
 ;;
 
 let pp_multi_underline ~(config : Config.t) ~severity ~priority ppf kind =
@@ -200,7 +208,7 @@ let pp_source_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
     match segment.stag with
     | Some { priority = Primary; _ } ->
       (* If primary, style the content *)
-      pp_label_styled_string ~config ~severity ~priority:Primary ppf content
+      pp_label_styled ~config ~severity ~priority:Primary Fmt.string ppf content
     | _ ->
       (* Otherwise, simply print the content *)
       Fmt.string ppf content
@@ -244,11 +252,10 @@ let pbox ~prefix pp ppf x =
 ;;
 
 (* prefixed-with-indent box *)
-let pwibox ~prefix pp ppf x =
+let pwibox ~prefix ~nprefix pp ppf x =
   let s = Fmt.str_like ppf "%a" pp x in
   let lines = split_lines_nonempty s in
   let nlines = List.length lines in
-  let nprefix = String.length prefix in
   List.iteri lines ~f:(fun i line ->
     if i = 0
     then Fmt.pf ppf "@[<h>%s%s@]" prefix line
@@ -283,16 +290,15 @@ module Multi_line_label = struct
   ;;
 
   let pp_bottom ~config ~severity ppf (width, priority, label) =
-    let prefix =
-      Fmt.str_like
-        ppf
-        "%a%a "
-        (pp_underlines ~config ~severity ~priority ~width)
-        `Bottom
-        (Chars.pp_multi_caret_end ~config ~severity ~priority)
-        ()
-    in
-    pwibox ~prefix (pp_message ~config ~severity ~priority) ppf label
+    Fmt.pf
+      ppf
+      "%a%a %a"
+      (pp_underlines ~config ~severity ~priority ~width)
+      `Bottom
+      (Chars.pp_multi_caret_end ~config ~severity ~priority)
+      ()
+      (pp_message ~config ~severity ~priority)
+      label
   ;;
 
   let pp_content_top ~ctxt ~(top : Multi_line_label.t option) pp ppf x =
@@ -476,15 +482,17 @@ module Inline_labels = struct
 end
 
 let pp_multi_line_label ~config ~severity ~ctxt ppf multi_line_label =
-  Fmt.pf
-    ppf
-    "@[<h>%*s %a %a@]"
-    ctxt.line_num_width
-    ""
-    (Chars.pp_source_border_left ~config)
-    ()
-    (Multi_line_label.pp ~config ~severity ~ctxt)
-    multi_line_label
+  (* equivalent to lbox but without multi_line, as that is handled internally *)
+  let prefix =
+    Fmt.str_like
+      ppf
+      "%*s %a "
+      ctxt.line_num_width
+      ""
+      (Chars.pp_source_border_left ~config)
+      ()
+  in
+  pbox ~prefix (Multi_line_label.pp ~config ~severity ~ctxt) ppf multi_line_label
 ;;
 
 let pp_line ~config ~severity ~ctxt ~lnum ppf (line : Line.t) =
@@ -611,6 +619,7 @@ let pp_note ~config ~line_num_width ppf note =
   pwibox
     ~prefix:
       (Fmt.str_like ppf "%*s %a " line_num_width "" (Chars.pp_note_bullet ~config) ())
+    ~nprefix:(line_num_width + 3)
     Message.pp
     ppf
     note

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1008,7 +1008,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 │ │  };
         │ ╰────' e2:
         │          new line of error 2
-        │ unboxed new line of error 2
+        │    unboxed new line of error 2
       5 │    baz
 
     unknown:1:1: error: err
@@ -1023,7 +1023,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 | |  };
         | \----' e2:
         |          new line of error 2
-        | unboxed new line of error 2
+        |    unboxed new line of error 2
       5 |    baz
 
     unknown:1:1: error: err
@@ -1036,7 +1036,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
           "e3: encapsulates everything"
         :: diagnostic.labels
     };
-  [%expect {|
+  [%expect
+    {|
     error: err
         ┌─ unknown:1:1
       1 │ ╭    foo
@@ -1047,8 +1048,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 │ │ ╭  bar {
       4 │ │ │  };
         │ │ ╰────' e2:
-        │            new line of error 2
-        │ unboxed new line of error 2
+        │ │          new line of error 2
+        │ │    unboxed new line of error 2
       5 │ │    baz
         │ ╰──────' e3: encapsulates everything
 
@@ -1063,8 +1064,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 | | /  bar {
       4 | | |  };
         | | \----' e2:
-        |            new line of error 2
-        | unboxed new line of error 2
+        | |          new line of error 2
+        | |    unboxed new line of error 2
       5 | |    baz
         | \------' e3: encapsulates everything
 

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1008,7 +1008,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 │ │  };
         │ ╰────' e2:
         │          new line of error 2
-        │    unboxed new line of error 2
+        │        unboxed new line of error 2
       5 │    baz
 
     unknown:1:1: error: err
@@ -1023,7 +1023,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 | |  };
         | \----' e2:
         |          new line of error 2
-        |    unboxed new line of error 2
+        |        unboxed new line of error 2
       5 |    baz
 
     unknown:1:1: error: err
@@ -1049,7 +1049,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 │ │ │  };
         │ │ ╰────' e2:
         │ │          new line of error 2
-        │ │    unboxed new line of error 2
+        │ │        unboxed new line of error 2
       5 │ │    baz
         │ ╰──────' e3: encapsulates everything
 
@@ -1065,7 +1065,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       4 | | |  };
         | | \----' e2:
         | |          new line of error 2
-        | |    unboxed new line of error 2
+        | |        unboxed new line of error 2
       5 | |    baz
         | \------' e3: encapsulates everything
 

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1,5 +1,6 @@
 open! Core
 open! Grace
+open! Grace_std
 open Diagnostic
 
 let source name content : Source.t =
@@ -10,19 +11,61 @@ let range ~source start stop =
   Range.create ~source (Byte_index.of_int start) (Byte_index.of_int stop)
 ;;
 
-let pr_diagnostics ?(config = Grace_ansi_renderer.Config.default) diagnostics =
+(* This code is Copyright (c) 2017 The b0 programmers.
+  SPDX-License-Identifier: ISC *)
+let strip_ansi_escapes s =
+  let len = String.length s in
+  let b = Buffer.create len in
+  let max = len - 1 in
+  let flush start stop =
+    if start < 0 || start > max
+    then ()
+    else Stdlib.Buffer.add_substring b s start (stop - start + 1)
+  in
+  let rec skip_esc i =
+    if i > max
+    then loop i i
+    else (
+      let k = i + 1 in
+      if s.[i] = 'm' then loop k k else skip_esc k)
+  and loop start i =
+    match i > max with
+    | true ->
+      if Buffer.length b = len
+      then s
+      else (
+        flush start max;
+        Buffer.contents b)
+    | false ->
+      (match s.[i] with
+       | '\x1B' ->
+         flush start (i - 1);
+         skip_esc (i + 1)
+       | _ -> loop start (i + 1))
+  in
+  loop 0 0
+;;
+
+let pr_diagnostics
+      ?(config = Grace_ansi_renderer.Config.default)
+      ?(ansi = false)
+      diagnostics
+  =
   let open Grace_ansi_renderer in
-  (* Disable colors for tests (since expect tests don't support ANSI colors) *)
-  let config = { config with use_ansi = Some false } in
-  Fmt.(
-    list
-      ~sep:(fun ppf () -> pf ppf "@.@.@.")
-      (fun ppf diagnostic ->
-         pp_diagnostic ~config ppf diagnostic;
-         pf ppf "@.@.";
-         pp_compact_diagnostic ~config ppf diagnostic))
-    Fmt.stdout
-    diagnostics
+  let config = { config with use_ansi = Some ansi } in
+  let output =
+    Fmt.(str_like stdout)
+      "%a"
+      Fmt.(
+        list
+          ~sep:(fun ppf () -> pf ppf "@.@.@.")
+          (fun ppf diagnostic ->
+             pp_diagnostic ~config ppf diagnostic;
+             pf ppf "@.@.";
+             pp_compact_diagnostic ~config ppf diagnostic))
+      diagnostics
+  in
+  print_endline (strip_ansi_escapes output)
 ;;
 
 let pr_bad_diagnostics ?(config = Grace_ansi_renderer.Config.default) diagnostics =
@@ -85,7 +128,7 @@ let%expect_test "same_line" =
   let source =
     source
       "one_line.rs"
-      {|  
+      {|
       > fn main() {
       >     let mut v = vec![Some("foo"), Some("bar")];
       >     v.push(v.pop().unwrap());
@@ -154,7 +197,7 @@ let%expect_test "overlapping" =
       "typeck_type_placeholder_item.rs"
       {|
       > fn fn_test1() -> _ { 5 }
-      > fn fn_test2(x: i32) -> (_, _) { (x, x) }  
+      > fn fn_test2(x: i32) -> (_, _) { (x, x) }
       |}
   in
   let s3 =
@@ -651,8 +694,8 @@ let%expect_test "multi-line empty messages" =
     source
       "rigid_variable_escape.ml"
       {|
-      > let escape = fun f -> 
-      >   fun (type a) -> 
+      > let escape = fun f ->
+      >   fun (type a) ->
       >     (f : a -> a)
       > ;;
       |}
@@ -920,5 +963,67 @@ let%expect_test "num_contextual_lines = 2 and enable_inline_contextual_lines = t
       4 │  line 4
 
     inline.ml:2:1: error: Testing inline labels without contextual lines
+|}]
+;;
+
+let%expect_test "label with multiple lines and ansi formatting" =
+  (* Bug #71: https://github.com/johnyob/grace/issues/71*)
+  let compare diagnostic =
+    pr_diagnostics ~ansi:true [ diagnostic ];
+    (* check consistency with non-unicode, non-ansi *)
+    pr_diagnostics
+      ~ansi:false
+      ~config:Grace_ansi_renderer.Config.{ default with chars = Chars.ascii }
+      [ diagnostic ]
+  in
+  let content = "foo\n\nbar {\n};\nbaz" in
+  let source : Source.t = `String { name = None; content } in
+  let diagnostic =
+    Diagnostic.(
+      createf
+        ~labels:
+          [ Label.primaryf
+              ~range:(range ~source 0 3)
+              "@[<v2>e1:@ new line of error1@]@ unboxed new line of error 1"
+          ; Label.secondaryf
+              ~range:(range ~source 5 14)
+              "@[<v2>e2:@ new line of error 2@]@ unboxed new line of error 2"
+          ]
+        Error
+        "err")
+  in
+  compare diagnostic;
+  [%expect
+    {|
+    error: err
+        ┌─ unknown:1:1
+      1 │    foo
+        │    ^^^ e1:
+        │          new line of error1
+        │    unboxed new line of error 1
+      2 │
+      3 │ ╭  bar {
+      4 │ │  };
+        │ ╰────' e2:
+                                         new line of error 2
+                                       unboxed new line of error 2
+      5 │    baz
+
+    unknown:1:1: error: err
+    error: err
+        --> unknown:1:1
+      1 |    foo
+        |    ^^^ e1:
+        |          new line of error1
+        |    unboxed new line of error 1
+      2 |
+      3 | /  bar {
+      4 | |  };
+        | \----' e2:
+          new line of error 2
+        unboxed new line of error 2
+      5 |    baz
+
+    unknown:1:1: error: err
     |}]
 ;;

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1027,5 +1027,47 @@ let%expect_test "label with multiple lines and ansi formatting" =
       5 |    baz
 
     unknown:1:1: error: err
+    |}];
+  compare
+    { diagnostic with
+      labels =
+        Diagnostic.Label.secondaryf
+          ~range:(range ~source 0 17)
+          "e3: encapsulates everything"
+        :: diagnostic.labels
+    };
+  [%expect {|
+    error: err
+        ┌─ unknown:1:1
+      1 │ ╭    foo
+        │ │    ^^^ e1:
+        │ │          new line of error1
+        │ │    unboxed new line of error 1
+      2 │ │
+      3 │ │ ╭  bar {
+      4 │ │ │  };
+        │ │ ╰────' e2:
+        │            new line of error 2
+        │ unboxed new line of error 2
+      5 │ │    baz
+        │ ╰──────' e3: encapsulates everything
+
+    unknown:1:1: error: err
+    error: err
+        --> unknown:1:1
+      1 | /    foo
+        | |    ^^^ e1:
+        | |          new line of error1
+        | |    unboxed new line of error 1
+      2 | |
+      3 | | /  bar {
+      4 | | |  };
+        | | \----' e2:
+        |            new line of error 2
+        | unboxed new line of error 2
+      5 | |    baz
+        | \------' e3: encapsulates everything
+
+    unknown:1:1: error: err
     |}]
 ;;

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -1,6 +1,5 @@
 open! Core
 open! Grace
-open! Grace_std
 open Diagnostic
 
 let source name content : Source.t =
@@ -11,6 +10,8 @@ let range ~source start stop =
   Range.create ~source (Byte_index.of_int start) (Byte_index.of_int stop)
 ;;
 
+(* Useful for testing, since we want to be able to show that turning on ANSI
+ doesn't break the alignment of other things! *)
 (* This code is Copyright (c) 2017 The b0 programmers.
   SPDX-License-Identifier: ISC *)
 let strip_ansi_escapes s =
@@ -27,7 +28,7 @@ let strip_ansi_escapes s =
     then loop i i
     else (
       let k = i + 1 in
-      if s.[i] = 'm' then loop k k else skip_esc k)
+      if Char.equal s.[i] 'm' then loop k k else skip_esc k)
   and loop start i =
     match i > max with
     | true ->
@@ -557,7 +558,8 @@ let%expect_test "unicode" =
        - unadjusted
        - vectorcall
        - win64
-       - x86-interrupt |}]
+       - x86-interrupt
+    |}]
 ;;
 
 let%expect_test "unicode spans" =
@@ -1005,8 +1007,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 │ ╭  bar {
       4 │ │  };
         │ ╰────' e2:
-                                         new line of error 2
-                                       unboxed new line of error 2
+        │          new line of error 2
+        │ unboxed new line of error 2
       5 │    baz
 
     unknown:1:1: error: err
@@ -1020,8 +1022,8 @@ let%expect_test "label with multiple lines and ansi formatting" =
       3 | /  bar {
       4 | |  };
         | \----' e2:
-          new line of error 2
-        unboxed new line of error 2
+        |          new line of error 2
+        | unboxed new line of error 2
       5 |    baz
 
     unknown:1:1: error: err


### PR DESCRIPTION
An alternative to #71 