### PR TITLE
Add vbox in inline labels

### DIFF
--- a/lib/ansi_renderer/snippet_renderer.ml
+++ b/lib/ansi_renderer/snippet_renderer.ml
@@ -442,11 +442,13 @@ module Inline_labels = struct
   let pp ~config ~severity ppf t =
     (* Print carets *)
     pp_carets ~config ~severity ppf t;
+    Format.pp_open_vbox ppf 0;
     (* Print trailing label *)
     pp_trailing_label ~config ~severity ppf t.trailing_segment;
     (* If non-empty, print the hanging segments *)
     if not (List.is_empty t.hanging_segments)
-    then Fmt.pf ppf "@.%a" (pp_hanging_segments ~config ~severity) t.hanging_segments
+    then Fmt.pf ppf "@.%a" (pp_hanging_segments ~config ~severity) t.hanging_segments;
+    Format.pp_close_box ppf ()
   ;;
 
   let as_trailing_segment { priority; offset; length; messages } : trailing_segment option

--- a/test/ansi_renderer/test_ansi_renderer.ml
+++ b/test/ansi_renderer/test_ansi_renderer.ml
@@ -473,7 +473,8 @@ let%expect_test "multiline_overlapping" =
         ┌─ file.rs:4:34
       1 │ ╭            match line_index.compare(self.last_line_index()) {
       2 │ │                Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
-        │ │                                  --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+        │ │                                  ---------------------------------------------
+        │ │     this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
       3 │ │                Ordering::Equal => Ok(self.source_span().end()),
         │ │                                   ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
       4 │ │                Ordering::Greater => LineIndexOutOfBoundsError {
@@ -746,7 +747,8 @@ let%expect_test "multi-label on large file" =
     error: Some dramatic error
         ┌─ inputs/snippet.ml:542:21
     148 │           ~compare:(Comparable.pair Diagnostic.Priority.compare Byte_index.compare)
-        │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error is happening here
+        │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        │   Error is happening here
         ·
     542 │          let locus = locus_of_labels ~sd labels in
         │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Bananad from here
@@ -1002,7 +1004,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       1 │    foo
         │    ^^^ e1:
         │          new line of error1
-        │    unboxed new line of error 1
+        │       unboxed new line of error 1
       2 │
       3 │ ╭  bar {
       4 │ │  };
@@ -1017,7 +1019,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       1 |    foo
         |    ^^^ e1:
         |          new line of error1
-        |    unboxed new line of error 1
+        |       unboxed new line of error 1
       2 |
       3 | /  bar {
       4 | |  };
@@ -1043,7 +1045,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       1 │ ╭    foo
         │ │    ^^^ e1:
         │ │          new line of error1
-        │ │    unboxed new line of error 1
+        │ │       unboxed new line of error 1
       2 │ │
       3 │ │ ╭  bar {
       4 │ │ │  };
@@ -1059,7 +1061,7 @@ let%expect_test "label with multiple lines and ansi formatting" =
       1 | /    foo
         | |    ^^^ e1:
         | |          new line of error1
-        | |    unboxed new line of error 1
+        | |       unboxed new line of error 1
       2 | |
       3 | | /  bar {
       4 | | |  };


### PR DESCRIPTION
Closes #89

This aligns the formatting between multi-line labels and inline labels. 

A few of the other tests change, I believe due to how far to the right they already are. Note that the output they are now showing is what they would have shown for a multi-line label before anyway, e.g. if you change line 774 of the test file to `pr_diagnostics (diagnostics (2930, 3015) (17511, 17537));` instead of `pr_diagnostics (diagnostics (2930, 3015) (17511, 17537));`